### PR TITLE
Fix #1

### DIFF
--- a/src/pages/lists.js
+++ b/src/pages/lists.js
@@ -104,11 +104,12 @@ class List extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    if (this.state !== nextState) {
-      return true
+    if (nextProps.match.params.id !== this.state.listname) {
+      this.updateListData(nextProps)
+      return false
     } else {
-      if (nextProps.match.params.id !== this.state.listname) {
-        this.updateListData(nextProps)
+      if (this.state !== nextState) {
+        return true
       }
       return false
     }


### PR DESCRIPTION
The `shouldComponentUpdate` method of `src/pages/lists.js`. It first checked the states and if they were different, it triggered an update. Otherwise, it checked for the url difference and called the method to update lists (`updateListData`). That was the reason for the bug. Now it does this in reverse, ie first check for url difference and then state difference.